### PR TITLE
Fix integration tests connect minio

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,8 +45,8 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: integration tests
       run: |
-        # check minio is up
-        curl -H "Authorization: AWS administrator:administrator" http://localhost:9000
+        # check minio is up, should return unauthorised
+        curl http://localhost:9000
         pytest
       env:
         MINIO_TEST_CONNECTION: localhost:9000

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,7 +2,7 @@ name: Integration tests and flake8
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, fix-integration-tests-connect-minio ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,7 +21,7 @@ jobs:
           MINIO_SECRET_KEY: administrator
         ports:
           - 9000:9000
-         options: server /data
+        options: server /data
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,7 +2,7 @@ name: Integration tests and flake8
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, fix-integration-tests-connect-minio ]
   pull_request:
     branches: [ master ]
 
@@ -19,6 +19,8 @@ jobs:
         env:
           MINIO_ACCESS_KEY: administrator
           MINIO_SECRET_KEY: administrator
+        ports:
+          - 9000:9000
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,10 +44,7 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: integration tests
-      run: |
-        # check minio is up, should return unauthorised
-        curl http://localhost:9000
-        pytest
+      run: pytest
       env:
         MINIO_TEST_CONNECTION: localhost:9000
         MINIO_TEST_ACCESS_KEY: administrator

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,9 +46,9 @@ jobs:
     - name: integration tests
       run: |
         # check minio is up
-        curl -H "Authorization: AWS administrator:administrator" http://minio:9000
+        curl -H "Authorization: AWS administrator:administrator" http://localhost:9000
         pytest
       env:
-        MINIO_TEST_CONNECTION: minio:9000
+        MINIO_TEST_CONNECTION: localhost:9000
         MINIO_TEST_ACCESS_KEY: administrator
         MINIO_TEST_SECRET_KEY: administrator

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,7 +2,7 @@ name: Integration tests and flake8
 
 on:
   push:
-    branches: [ master, fix-integration-tests-connect-minio ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,13 +15,14 @@ jobs:
     
     services:
       minio:
-        image: minio/minio
+        # Not using official minio image minio/minio because it requires arguments (start /data) 
+        # and github actions currently not supporting docker araguments
+        image: bitnami/minio
         env:
           MINIO_ACCESS_KEY: administrator
           MINIO_SECRET_KEY: administrator
         ports:
           - 9000:9000
-        options: server /data
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,7 +17,7 @@ jobs:
       minio:
         # Not using official minio image minio/minio because it requires arguments (start /data) 
         # and github actions currently not supporting docker araguments
-        # bitnami/minio image has 1M+ pulls and is up to date
+        # bitnami/minio image has 1M+ pulls and is up to date so it's should be OK to use it
         image: bitnami/minio
         env:
           MINIO_ACCESS_KEY: administrator

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,7 +2,7 @@ name: Integration tests and flake8
 
 on:
   push:
-    branches: [ master, fix-integration-tests-connect-minio ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -17,12 +17,14 @@ jobs:
       minio:
         # Not using official minio image minio/minio because it requires arguments (start /data) 
         # and github actions currently not supporting docker araguments
+        # bitnami/minio image has 1M+ pulls and is up to date
         image: bitnami/minio
         env:
           MINIO_ACCESS_KEY: administrator
           MINIO_SECRET_KEY: administrator
         ports:
           - 9000:9000
+        options: --name minio-server
 
     steps:
     - uses: actions/checkout@v2
@@ -42,7 +44,10 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: integration tests
-      run: pytest
+      run: |
+        # check minio is up
+        curl -H "Authorization: AWS administrator:administrator" http://minio:9000
+        pytest
       env:
         MINIO_TEST_CONNECTION: minio:9000
         MINIO_TEST_ACCESS_KEY: administrator

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,6 +21,7 @@ jobs:
           MINIO_SECRET_KEY: administrator
         ports:
           - 9000:9000
+         options: server /data
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
fix #19

* Official minio image needs arguments ("start /data"), move to image that do not require arguments
* Add curl command to check minio is up
* add ports mapping to minio and use localhost to connect to minio (using minio as dns to the IP does not work, I'm don't know 
why)

- [x] All tests are green.