### PR TITLE
Changing os.path to posixpath to prevent issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 
 I have developed pyminio while trying to work with the minio's original python client with a lot of struggles. I had to read and understand minio's implementations to preform the most simple tasks.
 
-Pyminio is a wrapper to minio, that is more indecative for the user.
+Pyminio is a wrapper to [minio](https://github.com/minio/minio-py), that is more indecative for the user.
 It works like `os` module, so you don't need to understand minio's concepts, and just using regular paths.
+
+The latest Pyminio supports minio >= 7.2
 
 ## Content
 1. [Installation](#installation)

--- a/pyminio/main.py
+++ b/pyminio/main.py
@@ -2,7 +2,7 @@ from collections import deque
 from datetime import datetime, timezone
 from functools import wraps
 from io import BytesIO
-from posixpath import basename, join, normpath, dirname
+from posixpath import basename, dirname, join, normpath
 from typing import Any, Callable, Dict, Iterable, List, Tuple, Type, TypeVar, Union
 
 from minio import Minio, datatypes

--- a/pyminio/main.py
+++ b/pyminio/main.py
@@ -2,8 +2,7 @@ from collections import deque
 from datetime import datetime, timezone
 from functools import wraps
 from io import BytesIO
-from os.path import basename, join, normpath
-from posixpath import dirname
+from posixpath import basename, join, normpath, dirname
 from typing import Any, Callable, Dict, Iterable, List, Tuple, Type, TypeVar, Union
 
 from minio import Minio, datatypes

--- a/pyminio/structures.py
+++ b/pyminio/structures.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import dataclass
 from functools import cached_property
-from os.path import join
+from posixpath import join
 from typing import Any, Dict
 
 ROOT = "/"

--- a/tests/test_pyminio.py
+++ b/tests/test_pyminio.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from os.path import join
+from posixpath import join
 from typing import Callable, Dict, Generator, List, Union
 
 import pytest


### PR DESCRIPTION
Changing os.path to posixpath to prevent issues when using pyminio in Windows environments.

os.path uses the current system file system separator and adjust all its functions to that. MinIO is always a posix path system. When using Pyminio in a Windows system, the paths got undesirable changed, because os.path set them to comply with Windows file system format.

This update prevents that issue to happen.

- [X] All tests are green.

Related issue:
https://github.com/IamTugy/pyminio/issues/36

![image](https://github.com/user-attachments/assets/bc15b9fc-9061-4f8c-8141-b55b611a4f0f)
